### PR TITLE
Make sample v9 compatible

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,7 @@ docker exec magento2-container bin/magento setup:upgrade
 
 # Configure the plugin
 docker exec magento2-container bin/magento config:set payment/adyen_abstract/demo_mode 1
+docker exec magento2-container bin/magento config:set payment/adyen_abstract/payment_methods_active 1
 docker exec magento2-container bin/magento adyen:enablepaymentmethods:run
 docker exec magento2-container bin/magento config:set payment/adyen_abstract/has_holder_name 1
 docker exec magento2-container bin/magento config:set payment/adyen_abstract/merchant_account "${ADYEN_MERCHANT_ACCOUNT}"
@@ -36,6 +37,9 @@ docker exec magento2-container bin/magento config:set payment/adyen_abstract/cli
 
 # Clear cache
 docker exec magento2-container bin/magento cache:flush
+
+# Setup upgrade
+docker exec magento2-container bin/magento setup:upgrade
 
 # Install Express Checkout
 docker exec magento2-container composer require adyen/adyen-magento2-expresscheckout

--- a/install.sh
+++ b/install.sh
@@ -47,8 +47,8 @@ docker exec magento2-container bin/magento module:enable Adyen_ExpressCheckout
 
 
 # Configure Express checkout module
-docker exec magento2-container bin/magento config:set payment/adyen_hpp/show_google_pay_on "1,2,3"
-docker exec magento2-container bin/magento config:set payment/adyen_hpp/show_apple_pay_on "1,2,3"
+docker exec magento2-container bin/magento config:set payment/adyen_express/show_google_pay_on "1,2,3"
+docker exec magento2-container bin/magento config:set payment/adyen_express/show_apple_pay_on "1,2,3"
 
 # Clear cache
 docker exec magento2-container bin/magento cache:flush

--- a/install.sh
+++ b/install.sh
@@ -23,24 +23,24 @@ docker exec magento2-container bin/magento setup:di:compile
 # Clear cache
 docker exec magento2-container bin/magento cache:flush
 
-# Install Express Checkout
-docker exec magento2-container composer require adyen/adyen-magento2-expresscheckout
-docker exec magento2-container bin/magento module:enable Adyen_ExpressCheckout
-
 # Setup upgrade
 docker exec magento2-container bin/magento setup:upgrade
+
+# Configure the plugin
+docker exec magento2-container bin/magento config:set payment/adyen_abstract/demo_mode 1
+docker exec magento2-container bin/magento adyen:enablepaymentmethods:run
+docker exec magento2-container bin/magento config:set payment/adyen_abstract/has_holder_name 1
+docker exec magento2-container bin/magento config:set payment/adyen_abstract/merchant_account "${ADYEN_MERCHANT_ACCOUNT}"
+docker exec magento2-container ./n98-magerun2.phar config:store:set --encrypt payment/adyen_abstract/api_key_test "${ADYEN_API_KEY}" > /dev/null
+docker exec magento2-container bin/magento config:set payment/adyen_abstract/client_key_test "${ADYEN_CLIENT_KEY}"
 
 # Clear cache
 docker exec magento2-container bin/magento cache:flush
 
-# Configure the plugin
-docker exec magento2-container bin/magento config:set payment/adyen_abstract/demo_mode 1
-docker exec magento2-container bin/magento config:set payment/adyen_hpp/active 1
-docker exec magento2-container bin/magento config:set payment/adyen_cc/active 1
-docker exec magento2-container bin/magento config:set payment/adyen_oneclick/active 1
-docker exec magento2-container bin/magento config:set payment/adyen_abstract/merchant_account "${ADYEN_MERCHANT_ACCOUNT}"
-docker exec magento2-container ./n98-magerun2.phar config:store:set --encrypt payment/adyen_abstract/api_key_test "${ADYEN_API_KEY}" > /dev/null
-docker exec magento2-container bin/magento config:set payment/adyen_abstract/client_key_test "${ADYEN_CLIENT_KEY}"
+# Install Express Checkout
+docker exec magento2-container composer require adyen/adyen-magento2-expresscheckout
+docker exec magento2-container bin/magento module:enable Adyen_ExpressCheckout
+
 
 # Configure Express checkout module
 docker exec magento2-container bin/magento config:set payment/adyen_hpp/show_google_pay_on "1,2,3"


### PR DESCRIPTION
This PR upgrades the `install.sh` script to be compatible with the v9 [Adobe Commerce plugin](https://github.com/Adyen/adyen-magento2/releases/tag/9.0.2).